### PR TITLE
Support blank values for checkbox

### DIFF
--- a/lib/active_record_bitmask/map.rb
+++ b/lib/active_record_bitmask/map.rb
@@ -2,6 +2,9 @@
 
 module ActiveRecordBitmask
   class Map
+    # Default blank values for checkbox
+    BLANK_VALUES = [:'', :'0'].freeze
+
     attr_reader :mapping
 
     # @param keys [Array<#to_sym>]
@@ -52,6 +55,7 @@ module ActiveRecordBitmask
     # @return [Integer]
     def attributes_to_bitmask(attributes)
       attributes = [attributes].compact unless attributes.respond_to?(:inject)
+      attributes = reject_blank_attributes(attributes)
 
       attributes.inject(0) do |bitmask, key|
         key = key.to_sym if key.respond_to?(:to_sym)
@@ -71,6 +75,12 @@ module ActiveRecordBitmask
     end
 
     private
+
+    def reject_blank_attributes(attributes)
+      attributes.reject do |value|
+        BLANK_VALUES.include?(value.to_s.to_sym)
+      end
+    end
 
     def attributes_to_mapping(keys)
       keys.each_with_index.each_with_object({}) do |(value, index), hash|

--- a/spec/active_record_bitmask/map_spec.rb
+++ b/spec/active_record_bitmask/map_spec.rb
@@ -67,7 +67,17 @@ RSpec.describe ActiveRecordBitmask::Map do
 
       context 'given 0' do
         let(:value) { 0 }
-        it { expect { subject }.to raise_error(ArgumentError) }
+        it { is_expected.to eq(0) }
+      end
+
+      context 'given ""' do
+        let(:value) { '' }
+        it { is_expected.to eq(0) }
+      end
+
+      context 'given "0"' do
+        let(:value) { '0' }
+        it { is_expected.to eq(0) }
       end
 
       context 'given [:a]' do
@@ -204,6 +214,11 @@ RSpec.describe ActiveRecordBitmask::Map do
 
       context 'given :unknown' do
         let(:value) { :unknown }
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+
+      context 'given "unknown"' do
+        let(:value) { 'unknown' }
         it { expect { subject }.to raise_error(ArgumentError) }
       end
     end


### PR DESCRIPTION
The ActionView `#check_box` helper renders checkbox with blank hidden input of unchecked.

```ruby
= form.check_box :attribute, { multiple: true }, 'value'
#=> <input name="attribute" type="hidden" value="0"><input type="checkbox" value="value" name="attribute">
```

Ignore those blank values to save record easily.