### PR TITLE
Fixed security alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,7 @@ gemspec
 
 gem 'pry'
 gem 'rubocop'
+gem 'appraisal'
+gem 'rake'
+gem 'rspec'
+gem 'sqlite3'

--- a/active_record_bitmask.gemspec
+++ b/active_record_bitmask.gemspec
@@ -20,8 +20,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activerecord', '>= 5.0'
-  spec.add_development_dependency 'appraisal'
-  spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'sqlite3'
 end

--- a/gemfiles/5.0_stable.gemfile
+++ b/gemfiles/5.0_stable.gemfile
@@ -4,7 +4,10 @@ source "https://rubygems.org"
 
 gem "pry"
 gem "rubocop"
-gem "activerecord", "~> 5.0.0"
+gem "appraisal"
+gem "rake"
+gem "rspec"
 gem "sqlite3", "~> 1.3.6"
+gem "activerecord", "~> 5.0.0"
 
 gemspec path: "../"

--- a/gemfiles/5.1_stable.gemfile
+++ b/gemfiles/5.1_stable.gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gem "pry"
 gem "rubocop"
+gem "appraisal"
+gem "rake"
+gem "rspec"
+gem "sqlite3"
 gem "activerecord", "~> 5.1.0"
 
 gemspec path: "../"

--- a/gemfiles/5.2_stable.gemfile
+++ b/gemfiles/5.2_stable.gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gem "pry"
 gem "rubocop"
+gem "appraisal"
+gem "rake"
+gem "rspec"
+gem "sqlite3"
 gem "activerecord", "~> 5.2.0"
 
 gemspec path: "../"

--- a/gemfiles/6.0_stable.gemfile
+++ b/gemfiles/6.0_stable.gemfile
@@ -4,6 +4,10 @@ source "https://rubygems.org"
 
 gem "pry"
 gem "rubocop"
+gem "appraisal"
+gem "rake"
+gem "rspec"
+gem "sqlite3"
 gem "activerecord", "~> 6.0.0"
 
 gemspec path: "../"


### PR DESCRIPTION
Dependency alerts says 'Upgrade rake to version 12.3.3 or later' but it has been used in only development.