### PR TITLE
`with_attribute` supports array of integer

### DIFF
--- a/lib/active_record_bitmask/map.rb
+++ b/lib/active_record_bitmask/map.rb
@@ -22,8 +22,15 @@ module ActiveRecordBitmask
     #
     # @return [Integer]
     def bitmask_or_attributes_to_bitmask(value)
-      value = bitmask_to_attributes(value) if value.is_a?(Integer)
-      attributes_to_bitmask(value)
+      values = Array.wrap(value).flat_map do |int_or_to_sym|
+        if int_or_to_sym.is_a?(Integer)
+          bitmask_to_attributes(int_or_to_sym)
+        else
+          int_or_to_sym
+        end
+      end
+
+      attributes_to_bitmask(values)
     end
 
     # @param bitmask [Integer]

--- a/spec/active_record_bitmask/map_spec.rb
+++ b/spec/active_record_bitmask/map_spec.rb
@@ -218,6 +218,26 @@ RSpec.describe ActiveRecordBitmask::Map do
         it { is_expected.to eq(127) }
       end
 
+      context 'with [1]' do
+        let(:value) { [1] }
+        it { is_expected.to eq(1) }
+      end
+
+      context 'with [3]' do
+        let(:value) { [3] }
+        it { is_expected.to eq(3) }
+      end
+
+      context 'with [1 3]' do
+        let(:value) { [1, 3] }
+        it { is_expected.to eq(3) }
+      end
+
+      context 'with [3 3]' do
+        let(:value) { [3, 3] }
+        it { is_expected.to eq(3) }
+      end
+
       context 'given :a' do
         let(:value) { :a }
         it { is_expected.to eq(1) }

--- a/spec/active_record_bitmask/model_spec.rb
+++ b/spec/active_record_bitmask/model_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe ActiveRecordBitmask::Model do
 
           context 'with 1' do
             let(:bitmask_or_attributes) { [1] }
-            it { expect { subject }.to raise_error(ArgumentError) }
+            it { is_expected.to contain_exactly(post_bitmask_1, post_bitmask_3) }
           end
 
           context 'with :unknown' do


### PR DESCRIPTION
scopes support array of integer.

```
Office.with_roles([1, 2, 3])
```