### PR TITLE
query methods supports string arguments

### DIFF
--- a/lib/active_record_bitmask/attribute_methods/query.rb
+++ b/lib/active_record_bitmask/attribute_methods/query.rb
@@ -13,10 +13,10 @@ module ActiveRecordBitmask
         if bitmask_attribute?(attribute_name) && values.present?
           # assert bitmask values
           map = self.class.bitmask_for(attribute_name)
-          map.attributes_to_bitmask(values)
+          expected_value = map.attributes_to_bitmask(values)
+          current_value = map.attributes_to_bitmask(attribute(attribute_name))
 
-          current_value = attribute(attribute_name)
-          values.all? { |value| current_value.include?(value) }
+          (current_value & expected_value) == expected_value
         else
           super
         end

--- a/lib/active_record_bitmask/model.rb
+++ b/lib/active_record_bitmask/model.rb
@@ -56,6 +56,7 @@ module ActiveRecordBitmask
         end
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def define_bitmask_scopes(attribute)
         blank = [0, nil].freeze
 
@@ -112,6 +113,7 @@ module ActiveRecordBitmask
           where(attribute => blank)
         }
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
     end
   end
 end

--- a/spec/active_record_bitmask/attribute_methods/query_spec.rb
+++ b/spec/active_record_bitmask/attribute_methods/query_spec.rb
@@ -8,8 +8,12 @@ RSpec.describe ActiveRecordBitmask::AttributeMethods::Query do
   end
 
   context '#attribute?' do
-    subject { instance.public_send(:"#{attribute}?") }
+    subject do
+      instance.public_send(:"#{attribute}?", *args)
+    end
+
     let(:instance) { Post.new }
+    let(:args) { [] }
 
     context 'with attribute' do
       let(:attribute) { 'column' }
@@ -74,6 +78,11 @@ RSpec.describe ActiveRecordBitmask::AttributeMethods::Query do
 
         context 'with :a' do
           subject { instance.bitmask?(:a) }
+          it { is_expected.to be true }
+        end
+
+        context 'with "a"' do
+          subject { instance.bitmask?('a') }
           it { is_expected.to be true }
         end
 


### PR DESCRIPTION
`user.role?(*values)` supports string arguments.