### PR TITLE
Deprecate attribute? for bitmask attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ You can check bitmask
 
 ```ruby
 post = Post.create(roles: [:provider, :guest])
-post.roles?(:provider) #=> false
-post.roles?(:guest, :provider) #=> true
+post.roles_bitmask?(:provider) #=> false
+post.roles_bitmask?(:guest, :provider) #=> true
 ```
 
 You can get the definition of bitmask

--- a/lib/active_record_bitmask/attribute_methods/query.rb
+++ b/lib/active_record_bitmask/attribute_methods/query.rb
@@ -1,15 +1,36 @@
 # frozen_string_literal: true
 
+require 'active_record'
+require 'active_support/concern'
+
 module ActiveRecordBitmask
   module AttributeMethods
     module Query
+      extend ActiveSupport::Concern
+
+      included do
+        attribute_method_suffix('_bitmask?')
+      end
+
       private
 
       def bitmask_attribute?(attribute_name)
         self.class.bitmasks.key?(attribute_name.to_sym)
       end
 
-      def attribute?(attribute_name, *values)
+      if ActiveRecord.gem_version < Gem::Version.create('7.0.0.alpha1')
+        # In Rails 7.0.0, calling attribute? with arguments is not working.
+        def attribute?(attribute_name, *values)
+          if bitmask_attribute?(attribute_name) && values.present?
+            ActiveSupport::Deprecation.warn("`#{attribute_name}?(*args)` is deprecated and will be removed in next major version. Call `#{attribute_name}_bitmask?(*args)` instead.")
+            attribute_bitmask?(attribute_name, *values)
+          else
+            super
+          end
+        end
+      end
+
+      def attribute_bitmask?(attribute_name, *values)
         if bitmask_attribute?(attribute_name) && values.present?
           # assert bitmask values
           map = self.class.bitmask_for(attribute_name)
@@ -18,7 +39,7 @@ module ActiveRecordBitmask
 
           (current_value & expected_value) == expected_value
         else
-          super
+          attribute?(attribute_name)
         end
       end
     end

--- a/spec/active_record_bitmask/attribute_methods/query_spec.rb
+++ b/spec/active_record_bitmask/attribute_methods/query_spec.rb
@@ -31,6 +31,120 @@ RSpec.describe ActiveRecordBitmask::AttributeMethods::Query do
       end
     end
 
+    if ActiveRecord.gem_version < Gem::Version.create('7.0.0.alpha1')
+      shared_examples_for 'deprecation warning' do
+        it 'renders deprecation warning' do
+          allow(ActiveSupport::Deprecation).to receive(:warn)
+
+          subject
+
+          expect(ActiveSupport::Deprecation).to have_received(:warn)
+            .with("`#{attribute}?(*args)` is deprecated and will be removed in next major version. Call `#{attribute}_bitmask?(*args)` instead.")
+        end
+      end
+
+      context 'with bitmask attribute' do
+        let(:attribute) { 'bitmask' }
+
+        context 'if value is not present' do
+          before do
+            instance.bitmask = value
+          end
+
+          context '0' do
+            let(:value) do
+              0
+            end
+
+            it { is_expected.to be false }
+          end
+
+          context '[]' do
+            let(:value) do
+              []
+            end
+
+            it { is_expected.to be false }
+          end
+
+          context 'nil' do
+            let(:value) do
+              nil
+            end
+
+            it { is_expected.to be false }
+          end
+        end
+
+        context 'if value is present' do
+          before do
+            instance.bitmask = 1
+          end
+
+          it { is_expected.to be true }
+
+          context 'without argument' do
+            let(:args) do
+              []
+            end
+
+            it { is_expected.to be true }
+          end
+
+          context 'with :a' do
+            let(:args) do
+              [:a]
+            end
+
+            it { is_expected.to be true }
+            it_should_behave_like 'deprecation warning'
+          end
+
+          context 'with "a"' do
+            let(:args) do
+              ['a']
+            end
+
+            it { is_expected.to be true }
+            it_should_behave_like 'deprecation warning'
+          end
+
+          context 'with :unknown' do
+            let(:args) do
+              [:unknown]
+            end
+
+            it { expect { subject }.to raise_error(ArgumentError) }
+          end
+        end
+      end
+    end
+  end
+
+  context '#attribute_bitmask?' do
+    subject do
+      instance.public_send(:"#{attribute}_bitmask?", *args)
+    end
+
+    let(:instance) { Post.new }
+    let(:args) { [] }
+
+    context 'with attribute' do
+      let(:attribute) { 'column' }
+
+      context 'if value is not present' do
+        it { is_expected.to be false }
+      end
+
+      context 'if value is present' do
+        before do
+          instance.column = 1
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+
     context 'with bitmask attribute' do
       let(:attribute) { 'bitmask' }
 
@@ -72,22 +186,34 @@ RSpec.describe ActiveRecordBitmask::AttributeMethods::Query do
         it { is_expected.to be true }
 
         context 'without argument' do
-          subject { instance.bitmask? }
+          let(:args) do
+            []
+          end
+
           it { is_expected.to be true }
         end
 
         context 'with :a' do
-          subject { instance.bitmask?(:a) }
+          let(:args) do
+            [:a]
+          end
+
           it { is_expected.to be true }
         end
 
         context 'with "a"' do
-          subject { instance.bitmask?('a') }
+          let(:args) do
+            ['a']
+          end
+
           it { is_expected.to be true }
         end
 
         context 'with :unknown' do
-          subject { instance.bitmask?(:unknown) }
+          let(:args) do
+            [:unknown]
+          end
+
           it { expect { subject }.to raise_error(ArgumentError) }
         end
       end


### PR DESCRIPTION
Deprecate attribute? with arguments for bitmask attributes

In Rails 7.0.0, `#attribute?` with arguments doesn't work.
Because rails/rails#41911 introduced new behavior for attribute methods to raise exception when unnecessary arguments given. Therefore can't use `attribute?` for bitmask in Rails 7.0.0.

This changes are followings.
- Warn deprecation when using `attribute?` for bitmask attribute.
- Add `attribute_bitmask?` to support same behavior. This works fine in Rails 7.0.0.