### PR TITLE
Release v0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.6
+
+* Deprecate `#attribute?(*args)` in favor of `#attribute_bitmask?(*args)`. #17
+* Support Rails 7.0.0.alpha1 #18
+
 ## 0.0.5
 
 * Support Rails 6.1.0 #14

--- a/lib/active_record_bitmask/version.rb
+++ b/lib/active_record_bitmask/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordBitmask
-  VERSION = '0.0.5'
+  VERSION = '0.0.6'
 end


### PR DESCRIPTION
* Deprecate `#attribute?(*args)` in favor of `#attribute_bitmask?(*args)`. #17
* Support Rails 7.0.0.alpha1 #18