### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Next Version
 
+## 1.0.0
+
+* **Breaking Changes** Rails 5.0, 5.1 and 5.2 are no longer supported. #23
 * Changed the version of rails specified in appraisal to stable version. #20
+* Migrate travis.ci to Github Actions #22
+* Support ruby 3.2 #24
 
 ## 0.0.6
 

--- a/active_record_bitmask.gemspec
+++ b/active_record_bitmask.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activerecord', '>= 5.0'
+  spec.add_dependency 'activerecord', '>= 6.0'
 end

--- a/lib/active_record_bitmask/version.rb
+++ b/lib/active_record_bitmask/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordBitmask
-  VERSION = '0.0.6'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
* **Breaking Changes** Rails 5.0, 5.1 and 5.2 are no longer supported. #23 
* Changed the version of rails specified in appraisal to stable version. #20
* Migrate travis.ci to Github Actions #22

