### PR TITLE
Bump up version to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Next Version
+## 2.0.0
 
 * **Breaking Changes** Rails 6.0 is no longer supported. #28
 * Support Rails 7.2.0 #27

--- a/lib/active_record_bitmask/version.rb
+++ b/lib/active_record_bitmask/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordBitmask
-  VERSION = '1.0.0'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
* **Breaking Changes** Rails 6.0 is no longer supported. #28
* Support Rails 7.2.0 #27
